### PR TITLE
Armoury Crate Game Profile Support: Keep launcher running in background and set as foreground window if needed

### DIFF
--- a/ShortCutes/Properties/AssemblyInfo.cs
+++ b/ShortCutes/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // Puede especificar todos los valores o usar los valores predeterminados de número de compilación y de revisión
 // utilizando el carácter "*", como se muestra a continuación:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.6")]
-[assembly: AssemblyFileVersion("1.5.6")]
+[assembly: AssemblyVersion("1.5.7")]
+[assembly: AssemblyFileVersion("1.5.7")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/ShortCutes/ShortCutesForm.Designer.cs
+++ b/ShortCutes/ShortCutesForm.Designer.cs
@@ -31,7 +31,6 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ShortCutes));
             this.label5 = new System.Windows.Forms.Label();
-            this.DesktopCheck = new System.Windows.Forms.CheckBox();
             this.GameExplorerBtn = new System.Windows.Forms.Button();
             this.EmuExplorerBtn = new System.Windows.Forms.Button();
             this.ShortCuteNameTxB = new System.Windows.Forms.TextBox();
@@ -51,12 +50,13 @@
             this.label7 = new System.Windows.Forms.Label();
             this.miniBtn = new System.Windows.Forms.Button();
             this.closeBtn = new System.Windows.Forms.Button();
+            this.OpenFolder = new System.Windows.Forms.Button();
             this.ICOurl = new System.Windows.Forms.TextBox();
             this.ICOpic = new System.Windows.Forms.PictureBox();
             this.ClearSCSelected = new System.Windows.Forms.Button();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.forceWindowToNotWait = new System.Windows.Forms.CheckBox();
-            this.OpenFolder = new System.Windows.Forms.Button();
+            this.armoryCrateLauncher = new System.Windows.Forms.CheckBox();
             this.Timer = new System.Windows.Forms.Timer(this.components);
             this.panelBorderStyle.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ICOpic)).BeginInit();
@@ -66,28 +66,13 @@
             // 
             this.label5.Font = new System.Drawing.Font("Bahnschrift SemiBold SemiConden", 9.75F, System.Drawing.FontStyle.Bold);
             this.label5.ForeColor = System.Drawing.Color.White;
-            this.label5.Location = new System.Drawing.Point(443, 42);
+            this.label5.Location = new System.Drawing.Point(443, 45);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(303, 35);
             this.label5.TabIndex = 27;
             this.label5.Text = "Select an  image to set as the shortcut ICON\r\nDouble click to crop selected image" +
     "";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // DesktopCheck
-            // 
-            this.DesktopCheck.AutoSize = true;
-            this.DesktopCheck.Checked = true;
-            this.DesktopCheck.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.DesktopCheck.Font = new System.Drawing.Font("Bahnschrift SemiCondensed", 9.75F);
-            this.DesktopCheck.ForeColor = System.Drawing.Color.White;
-            this.DesktopCheck.Location = new System.Drawing.Point(12, 311);
-            this.DesktopCheck.Name = "DesktopCheck";
-            this.DesktopCheck.Size = new System.Drawing.Size(113, 20);
-            this.DesktopCheck.TabIndex = 5;
-            this.DesktopCheck.Text = "Desktop Shortcut";
-            this.DesktopCheck.UseVisualStyleBackColor = true;
-            this.DesktopCheck.CheckedChanged += new System.EventHandler(this.Shortcutbox_Focus);
             // 
             // GameExplorerBtn
             // 
@@ -97,7 +82,7 @@
             this.GameExplorerBtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.GameExplorerBtn.Font = new System.Drawing.Font("Bahnschrift Condensed", 11.25F, System.Drawing.FontStyle.Bold);
             this.GameExplorerBtn.ForeColor = System.Drawing.Color.White;
-            this.GameExplorerBtn.Location = new System.Drawing.Point(302, 261);
+            this.GameExplorerBtn.Location = new System.Drawing.Point(302, 265);
             this.GameExplorerBtn.Name = "GameExplorerBtn";
             this.GameExplorerBtn.Size = new System.Drawing.Size(119, 35);
             this.GameExplorerBtn.TabIndex = 3;
@@ -113,7 +98,7 @@
             this.EmuExplorerBtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.EmuExplorerBtn.Font = new System.Drawing.Font("Bahnschrift Condensed", 11.25F, System.Drawing.FontStyle.Bold);
             this.EmuExplorerBtn.ForeColor = System.Drawing.Color.White;
-            this.EmuExplorerBtn.Location = new System.Drawing.Point(302, 192);
+            this.EmuExplorerBtn.Location = new System.Drawing.Point(302, 196);
             this.EmuExplorerBtn.Name = "EmuExplorerBtn";
             this.EmuExplorerBtn.Size = new System.Drawing.Size(119, 35);
             this.EmuExplorerBtn.TabIndex = 2;
@@ -127,7 +112,7 @@
             this.ShortCuteNameTxB.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.ShortCuteNameTxB.Font = new System.Drawing.Font("Bahnschrift Light SemiCondensed", 12F);
             this.ShortCuteNameTxB.ForeColor = System.Drawing.Color.White;
-            this.ShortCuteNameTxB.Location = new System.Drawing.Point(12, 130);
+            this.ShortCuteNameTxB.Location = new System.Drawing.Point(14, 133);
             this.ShortCuteNameTxB.MaxLength = 50;
             this.ShortCuteNameTxB.Multiline = true;
             this.ShortCuteNameTxB.Name = "ShortCuteNameTxB";
@@ -142,7 +127,7 @@
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Bahnschrift SemiBold SemiConden", 9.75F, System.Drawing.FontStyle.Bold);
             this.label4.ForeColor = System.Drawing.Color.White;
-            this.label4.Location = new System.Drawing.Point(14, 111);
+            this.label4.Location = new System.Drawing.Point(14, 114);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(85, 16);
             this.label4.TabIndex = 25;
@@ -164,7 +149,7 @@
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Bahnschrift SemiBold SemiConden", 9.75F, System.Drawing.FontStyle.Bold);
             this.label2.ForeColor = System.Drawing.Color.White;
-            this.label2.Location = new System.Drawing.Point(14, 242);
+            this.label2.Location = new System.Drawing.Point(14, 246);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(110, 16);
             this.label2.TabIndex = 23;
@@ -175,7 +160,7 @@
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Bahnschrift SemiBold SemiConden", 9.75F, System.Drawing.FontStyle.Bold);
             this.label1.ForeColor = System.Drawing.Color.White;
-            this.label1.Location = new System.Drawing.Point(14, 172);
+            this.label1.Location = new System.Drawing.Point(14, 176);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(106, 16);
             this.label1.TabIndex = 20;
@@ -202,7 +187,7 @@
             this.EmuDirTxB.Cursor = System.Windows.Forms.Cursors.Default;
             this.EmuDirTxB.Font = new System.Drawing.Font("Bahnschrift Light SemiCondensed", 9F);
             this.EmuDirTxB.ForeColor = System.Drawing.Color.White;
-            this.EmuDirTxB.Location = new System.Drawing.Point(14, 192);
+            this.EmuDirTxB.Location = new System.Drawing.Point(14, 196);
             this.EmuDirTxB.Multiline = true;
             this.EmuDirTxB.Name = "EmuDirTxB";
             this.EmuDirTxB.ReadOnly = true;
@@ -220,7 +205,7 @@
             this.GameDirTxB.Cursor = System.Windows.Forms.Cursors.Default;
             this.GameDirTxB.Font = new System.Drawing.Font("Bahnschrift Light SemiCondensed", 9F);
             this.GameDirTxB.ForeColor = System.Drawing.Color.White;
-            this.GameDirTxB.Location = new System.Drawing.Point(14, 261);
+            this.GameDirTxB.Location = new System.Drawing.Point(14, 265);
             this.GameDirTxB.Multiline = true;
             this.GameDirTxB.Name = "GameDirTxB";
             this.GameDirTxB.ReadOnly = true;
@@ -238,7 +223,7 @@
             this.createshortbtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.createshortbtn.Font = new System.Drawing.Font("Bahnschrift SemiCondensed", 14.25F, System.Drawing.FontStyle.Bold);
             this.createshortbtn.ForeColor = System.Drawing.Color.White;
-            this.createshortbtn.Location = new System.Drawing.Point(12, 337);
+            this.createshortbtn.Location = new System.Drawing.Point(12, 348);
             this.createshortbtn.Name = "createshortbtn";
             this.createshortbtn.Size = new System.Drawing.Size(409, 65);
             this.createshortbtn.TabIndex = 4;
@@ -372,13 +357,32 @@
             this.closeBtn.UseVisualStyleBackColor = false;
             this.closeBtn.Click += new System.EventHandler(this.CloseBtn_Click);
             // 
+            // OpenFolder
+            // 
+            this.OpenFolder.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(13)))), ((int)(((byte)(18)))), ((int)(((byte)(23)))));
+            this.OpenFolder.FlatAppearance.BorderSize = 0;
+            this.OpenFolder.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(56)))), ((int)(((byte)(74)))));
+            this.OpenFolder.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.OpenFolder.Font = new System.Drawing.Font("Bahnschrift SemiCondensed", 7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.OpenFolder.ForeColor = System.Drawing.Color.White;
+            this.OpenFolder.Location = new System.Drawing.Point(302, 314);
+            this.OpenFolder.Margin = new System.Windows.Forms.Padding(0);
+            this.OpenFolder.Name = "OpenFolder";
+            this.OpenFolder.Size = new System.Drawing.Size(119, 21);
+            this.OpenFolder.TabIndex = 32;
+            this.OpenFolder.TabStop = false;
+            this.OpenFolder.Text = "Open ShortCutes Folder";
+            this.OpenFolder.TextImageRelation = System.Windows.Forms.TextImageRelation.TextAboveImage;
+            this.OpenFolder.UseVisualStyleBackColor = false;
+            this.OpenFolder.Click += new System.EventHandler(this.OpenFolder_Click);
+            // 
             // ICOurl
             // 
             this.ICOurl.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(30)))), ((int)(((byte)(30)))));
             this.ICOurl.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.ICOurl.Font = new System.Drawing.Font("Bahnschrift Light SemiCondensed", 11F);
             this.ICOurl.ForeColor = System.Drawing.Color.White;
-            this.ICOurl.Location = new System.Drawing.Point(446, 382);
+            this.ICOurl.Location = new System.Drawing.Point(446, 389);
             this.ICOurl.Multiline = true;
             this.ICOurl.Name = "ICOurl";
             this.ICOurl.Size = new System.Drawing.Size(300, 22);
@@ -397,7 +401,7 @@
             this.ICOpic.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
             this.ICOpic.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.ICOpic.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.ICOpic.Location = new System.Drawing.Point(446, 76);
+            this.ICOpic.Location = new System.Drawing.Point(446, 83);
             this.ICOpic.Name = "ICOpic";
             this.ICOpic.Size = new System.Drawing.Size(300, 300);
             this.ICOpic.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
@@ -414,7 +418,7 @@
             this.ClearSCSelected.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ClearSCSelected.Font = new System.Drawing.Font("Bahnschrift Condensed", 11.25F, System.Drawing.FontStyle.Bold);
             this.ClearSCSelected.ForeColor = System.Drawing.Color.White;
-            this.ClearSCSelected.Location = new System.Drawing.Point(302, 125);
+            this.ClearSCSelected.Location = new System.Drawing.Point(302, 123);
             this.ClearSCSelected.Name = "ClearSCSelected";
             this.ClearSCSelected.Size = new System.Drawing.Size(119, 35);
             this.ClearSCSelected.TabIndex = 31;
@@ -434,33 +438,28 @@
             // forceWindowToNotWait
             // 
             this.forceWindowToNotWait.AutoSize = true;
-            this.forceWindowToNotWait.Font = new System.Drawing.Font("Bahnschrift SemiCondensed", 9.75F);
+            this.forceWindowToNotWait.Font = new System.Drawing.Font("Bahnschrift SemiCondensed", 9F);
             this.forceWindowToNotWait.ForeColor = System.Drawing.Color.White;
-            this.forceWindowToNotWait.Location = new System.Drawing.Point(131, 311);
+            this.forceWindowToNotWait.Location = new System.Drawing.Point(12, 315);
             this.forceWindowToNotWait.Name = "forceWindowToNotWait";
-            this.forceWindowToNotWait.Size = new System.Drawing.Size(144, 20);
+            this.forceWindowToNotWait.Size = new System.Drawing.Size(139, 18);
             this.forceWindowToNotWait.TabIndex = 33;
             this.forceWindowToNotWait.Text = "Force launcher to close";
             this.toolTip.SetToolTip(this.forceWindowToNotWait, "Forces ShortCute launcher to close when the emulator exe has already opened");
             this.forceWindowToNotWait.UseVisualStyleBackColor = true;
             // 
-            // OpenFolder
+            // armoryCrateLauncher
             // 
-            this.OpenFolder.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(13)))), ((int)(((byte)(18)))), ((int)(((byte)(23)))));
-            this.OpenFolder.FlatAppearance.BorderSize = 0;
-            this.OpenFolder.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(56)))), ((int)(((byte)(74)))));
-            this.OpenFolder.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.OpenFolder.Font = new System.Drawing.Font("Bahnschrift SemiCondensed", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.OpenFolder.ForeColor = System.Drawing.Color.White;
-            this.OpenFolder.Location = new System.Drawing.Point(302, 306);
-            this.OpenFolder.Margin = new System.Windows.Forms.Padding(0);
-            this.OpenFolder.Name = "OpenFolder";
-            this.OpenFolder.Size = new System.Drawing.Size(119, 23);
-            this.OpenFolder.TabIndex = 32;
-            this.OpenFolder.TabStop = false;
-            this.OpenFolder.Text = "Open ShortCutes Folder";
-            this.OpenFolder.UseVisualStyleBackColor = false;
-            this.OpenFolder.Click += new System.EventHandler(this.OpenFolder_Click);
+            this.armoryCrateLauncher.AutoSize = true;
+            this.armoryCrateLauncher.Font = new System.Drawing.Font("Bahnschrift SemiCondensed", 9F);
+            this.armoryCrateLauncher.ForeColor = System.Drawing.Color.White;
+            this.armoryCrateLauncher.Location = new System.Drawing.Point(157, 315);
+            this.armoryCrateLauncher.Name = "armoryCrateLauncher";
+            this.armoryCrateLauncher.Size = new System.Drawing.Size(135, 18);
+            this.armoryCrateLauncher.TabIndex = 34;
+            this.armoryCrateLauncher.Text = "Armory Crate launcher";
+            this.toolTip.SetToolTip(this.armoryCrateLauncher, "Enables compatibility with Armory Crate game profiles");
+            this.armoryCrateLauncher.UseVisualStyleBackColor = true;
             // 
             // Timer
             // 
@@ -472,15 +471,15 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(28)))), ((int)(((byte)(38)))));
-            this.ClientSize = new System.Drawing.Size(760, 415);
+            this.ClientSize = new System.Drawing.Size(760, 420);
             this.ControlBox = false;
-            this.Controls.Add(this.forceWindowToNotWait);
+            this.Controls.Add(this.armoryCrateLauncher);
             this.Controls.Add(this.OpenFolder);
+            this.Controls.Add(this.forceWindowToNotWait);
             this.Controls.Add(this.ClearSCSelected);
             this.Controls.Add(this.ICOurl);
             this.Controls.Add(this.panelBorderStyle);
             this.Controls.Add(this.label6);
-            this.Controls.Add(this.DesktopCheck);
             this.Controls.Add(this.ICOpic);
             this.Controls.Add(this.GameExplorerBtn);
             this.Controls.Add(this.EmuExplorerBtn);
@@ -513,7 +512,6 @@
         #endregion
 
         private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.CheckBox DesktopCheck;
         private System.Windows.Forms.PictureBox ICOpic;
         private System.Windows.Forms.Button GameExplorerBtn;
         private System.Windows.Forms.Button EmuExplorerBtn;
@@ -540,6 +538,7 @@
         private System.Windows.Forms.Button OpenFolder;
         private System.Windows.Forms.Timer Timer;
         private System.Windows.Forms.CheckBox forceWindowToNotWait;
+        private System.Windows.Forms.CheckBox armoryCrateLauncher;
     }
 }
 

--- a/ShortCutes/ShortCutesForm.cs
+++ b/ShortCutes/ShortCutesForm.cs
@@ -126,7 +126,7 @@ namespace ShortCutes
 
             // For Armoury Crate on ROG Ally set keepLauncherOpen and keepLauncherActive to true and keepActiveDuration to 5000 ms
             string codeToCompile = Utils.Roslyn_FormCode(SelectedEmu, ShortCuteNameTxB.Text, GameDirTxB.Text.Replace(Utils.GetDirectoryName(EmuDirTxB.Text), @""),
-                await GetImageColor(), forceWindowToNotWait.Checked, false, false, 0);
+                await GetImageColor(), forceWindowToNotWait.Checked, armoryCrateLauncher.Checked, armoryCrateLauncher.Checked, armoryCrateLauncher.Checked ? 5000 : 0);
 
             string emuPath = Utils.GetDirectoryName(EmuDirTxB.Text) + "ShortCutes";
             if (!Directory.Exists(emuPath))
@@ -141,8 +141,7 @@ namespace ShortCutes
             if (insertInHistory(emuPath))
                 message = message.Replace("created", "modified");
 
-            if (DesktopCheck.Checked)
-                Utils.CreateShortcut(ShortCuteNameTxB.Text, Output, emuPath);
+            Utils.CreateShortcut(ShortCuteNameTxB.Text, Output, emuPath);
 
             Cursor = Cursors.Default;
             Application.UseWaitCursor = false;

--- a/ShortCutes/ShortCutesForm.cs
+++ b/ShortCutes/ShortCutesForm.cs
@@ -124,8 +124,9 @@ namespace ShortCutes
             Application.UseWaitCursor = true;
             string message = "Shortcut created!\nExecute shortcut?";
 
+            // For Armoury Crate on ROG Ally set keepLauncherOpen and keepLauncherActive to true and keepActiveDuration to 5000 ms
             string codeToCompile = Utils.Roslyn_FormCode(SelectedEmu, ShortCuteNameTxB.Text, GameDirTxB.Text.Replace(Utils.GetDirectoryName(EmuDirTxB.Text), @""),
-                await GetImageColor(), forceWindowToNotWait.Checked, true, true, 3000);
+                await GetImageColor(), forceWindowToNotWait.Checked, true, true, 5000);
 
             string emuPath = Utils.GetDirectoryName(EmuDirTxB.Text) + "ShortCutes";
             if (!Directory.Exists(emuPath))

--- a/ShortCutes/ShortCutesForm.cs
+++ b/ShortCutes/ShortCutesForm.cs
@@ -126,7 +126,7 @@ namespace ShortCutes
 
             // For Armoury Crate on ROG Ally set keepLauncherOpen and keepLauncherActive to true and keepActiveDuration to 5000 ms
             string codeToCompile = Utils.Roslyn_FormCode(SelectedEmu, ShortCuteNameTxB.Text, GameDirTxB.Text.Replace(Utils.GetDirectoryName(EmuDirTxB.Text), @""),
-                await GetImageColor(), forceWindowToNotWait.Checked, true, true, 5000);
+                await GetImageColor(), forceWindowToNotWait.Checked, false, false, 0);
 
             string emuPath = Utils.GetDirectoryName(EmuDirTxB.Text) + "ShortCutes";
             if (!Directory.Exists(emuPath))

--- a/ShortCutes/ShortCutesForm.cs
+++ b/ShortCutes/ShortCutesForm.cs
@@ -125,7 +125,7 @@ namespace ShortCutes
             string message = "Shortcut created!\nExecute shortcut?";
 
             string codeToCompile = Utils.Roslyn_FormCode(SelectedEmu, ShortCuteNameTxB.Text, GameDirTxB.Text.Replace(Utils.GetDirectoryName(EmuDirTxB.Text), @""),
-                await GetImageColor(), forceWindowToNotWait.Checked);
+                await GetImageColor(), forceWindowToNotWait.Checked, true, true, 3000);
 
             string emuPath = Utils.GetDirectoryName(EmuDirTxB.Text) + "ShortCutes";
             if (!Directory.Exists(emuPath))

--- a/ShortCutes/src/Roslyn Form Code.cs
+++ b/ShortCutes/src/Roslyn Form Code.cs
@@ -17,8 +17,9 @@ namespace Shortcutes.src
 		private PictureBox PictureBoxSC;
 		private PictureBox PBFade;
 		private Timer TimerSC = new Timer();
+		private bool isMouseDown = false;
 
-		private Image TextImage;
+        private Image TextImage;
 
 		private int GrowInt = 1;
 		Process ShortCute = new Process();
@@ -155,10 +156,13 @@ namespace Shortcutes.src
 				TimerSC.Stop();
 
 				PBFade.MouseDown += FormDisp_MouseDown;
-				PictureBoxSC.MouseDown += FormDisp_MouseDown;
-				PictureBoxImage.MouseDown += FormDisp_MouseDown;
+				PBFade.MouseUp += FormDisp_MouseUp;
+                PictureBoxSC.MouseDown += FormDisp_MouseDown;
+                PictureBoxSC.MouseUp += FormDisp_MouseUp;
+                PictureBoxImage.MouseDown += FormDisp_MouseDown;
+                PictureBoxImage.MouseUp += FormDisp_MouseUp;
 
-				TimerSC.Interval = 1;
+                TimerSC.Interval = 1;
 				TimerSC.Tick -= GrowForm;
 				TimerSC.Tick += MovePB;
 				TimerSC.Start();
@@ -199,7 +203,7 @@ namespace Shortcutes.src
 			Top -= GrowInt / 2;
 			CLOSEbutton.Hide();
 
-			if (ClientSize.Height <= 72 + Math.Abs(GrowInt)*2)
+			if ((ClientSize.Height <= 72 + Math.Abs(GrowInt)*2) && hWinEventHook != IntPtr.Zero)
 				PictureBoxImage.Image = null;
 
 			if (ClientSize.Height < 72 / 1.5)
@@ -216,7 +220,21 @@ namespace Shortcutes.src
 					// Register a WineventHook to get notified on foreground window change
 					if (KeepLauncherActive)
 					{
-						procDelegate = new WinEventDelegate(WinEventProc);
+						ClientSize = new Size(256, standarHeight);
+                        PictureBoxSC.Location = new Point(0, PBHeight);
+						Top = ((Screen.PrimaryScreen.WorkingArea.Height - Height) / 2) - (standarHeight / 2);
+
+                        TextImage = new Bitmap(256, standarHeight);
+                        using (Graphics graph = Graphics.FromImage(TextImage))
+                        {
+                            graph.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+                            graph.DrawString("Armory Crate:", new Font("Bahnschrift SemiCondensed", 12F), Brushes.White, 0, 3);
+                            graph.DrawString(" " + "Applying profile", new Font("Bahnschrift SemiCondensed", 20F), Brushes.White, 0, 23);
+                            graph.DrawString("Created by Haruki1707", new Font("Bahnschrift SemiCondensed", 6F), Brushes.DimGray, 0, 56);
+                            PictureBoxSC.BackgroundImage = TextImage;
+                        }
+
+                        procDelegate = new WinEventDelegate(WinEventProc);
 						hWinEventHook = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, IntPtr.Zero, procDelegate, 0, 0, WINEVENT_OUTOFCONTEXT);
 					}
 				}
@@ -309,8 +327,11 @@ namespace Shortcutes.src
 
 		private void CloseForm()
         {
-			mouse_event(MOUSEEVENTF_LEFTUP, (uint)MousePosition.X, (uint)MousePosition.Y, 0, 0);
-			mouse_event(MOUSEEVENTF_RIGHTUP, (uint)MousePosition.X, (uint)MousePosition.Y, 0, 0);
+			if (isMouseDown)
+			{
+				mouse_event(MOUSEEVENTF_LEFTUP, (uint)MousePosition.X, (uint)MousePosition.Y, 0, 0);
+				mouse_event(MOUSEEVENTF_RIGHTUP, (uint)MousePosition.X, (uint)MousePosition.Y, 0, 0);
+			}
             PBFade.MouseDown -= FormDisp_MouseDown;
 			PictureBoxSC.MouseDown -= FormDisp_MouseDown;
 			PictureBoxImage.MouseDown -= FormDisp_MouseDown;
@@ -416,12 +437,18 @@ namespace Shortcutes.src
 
 		private void FormDisp_MouseDown(object sender, MouseEventArgs e)
 		{
+			isMouseDown = true;
 			ReleaseCapture();
 			SendMessage(this.Handle, 0x112, 0xf012, 0);
 		}
 
-		//Enable form over any other app
-		protected override CreateParams CreateParams
+		private void FormDisp_MouseUp(object sender, MouseEventArgs e)
+        {
+            isMouseDown = false;
+        }
+
+        //Enable form over any other app
+        protected override CreateParams CreateParams
 		{
 			get
 			{

--- a/ShortCutes/src/Roslyn Form Code.cs
+++ b/ShortCutes/src/Roslyn Form Code.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Windows.Forms;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace Shortcutes.src
 {
@@ -28,9 +29,9 @@ namespace Shortcutes.src
 		private string GameName = "%GAME%";
 		private static int standarHeight = %HEIGHT%;
 		private bool WaitForWindowChange = %WAITCHANGE%;
-		private bool KeepLauncherOpen = true; // don't close the launcher after the emulator is started, but keep it running in the background
-		private bool KeepLauncherActive = true; // needs to have KeepLauncherOpen enabled. Keep the launcher active for a certain duration each time the emulator is focused
-		private int ActiveDuration = 3000; // Duration in milliseconds for which the launcher will be active
+		private bool KeepLauncherOpen = %KEEPOPEN%; // don't close the launcher after the emulator is started, but keep it running in the background
+		private bool KeepLauncherActive = %KEEPACTIVE%; // needs to have KeepLauncherOpen enabled. Keep the launcher active for a certain duration each time the emulator is focused
+		private int ActiveDuration = %KEEPACTIVEDURATION%; // Duration in milliseconds for which the launcher will be active
 		private Color avgColor = Color.FromArgb(%avgR%, %avgG%, %avgB%);
 		System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
 
@@ -353,7 +354,7 @@ namespace Shortcutes.src
 					IntPtr mainWindowHandle = this.Handle;
 
 					// Application.OpenForms[0] replaced with this
-					this.Invoke(new Action(() =>
+					this.Invoke(new Func<Task>(async () =>
 					{
 						try
 						{
@@ -365,7 +366,7 @@ namespace Shortcutes.src
 							SetForegroundWindow(mainWindowHandle);
 
 							// Wait for the specified delay duration before hiding the window again
-                        	await Task.Delay(delayDuration);
+                        	await Task.Delay(ActiveDuration);
 
 							// Hide the CuteLauncher window again and make sure the emulator is the foreground window
 							this.WindowState = FormWindowState.Minimized;

--- a/ShortCutes/src/Roslyn Form Code.cs
+++ b/ShortCutes/src/Roslyn Form Code.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using System.Drawing;
@@ -28,6 +28,7 @@ namespace Shortcutes.src
 		private string GameName = "%GAME%";
 		private static int standarHeight = %HEIGHT%;
 		private bool WaitForWindowChange = %WAITCHANGE%;
+		private bool KeepLauncherOpen = true; // don't close the launcher after the emulator is started, but keep it running in the background
 		private Color avgColor = Color.FromArgb(%avgR%, %avgG%, %avgB%);
 		System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
 
@@ -178,7 +179,17 @@ namespace Shortcutes.src
 			{
 				TimerSC.Stop();
 				SetForegroundWindow(ShortCute.Handle.ToInt32());
-				Close();
+				// if KeepLauncherOpen is enabled, we minimize the launcher only 
+				// and close it on Emulator exit instead
+				if (KeepLauncherOpen)
+				{
+					this.WindowState = FormWindowState.Minimized;
+                    this.Hide();
+				}
+				else
+				{
+					Close();
+				}
                 SetForegroundWindow(ShortCute.Handle.ToInt32());
             }
         }
@@ -207,6 +218,8 @@ namespace Shortcutes.src
 			ShortCute.StartInfo.WorkingDirectory = "..\\";
 			ShortCute.StartInfo.FileName = "..\\" + Emulator;
 			ShortCute.StartInfo.Arguments = arguments;
+			ShortCute.EnableRaisingEvents = true; // enable notification on process exit
+            ShortCute.Exited += Emulator_Exited; // notify on process exit
 			ShortCute.Start();
 
 			TimerSC.Interval = 250;
@@ -275,6 +288,10 @@ namespace Shortcutes.src
 			TimerSC.Tick += ShrinkForm;
 			TimerSC.Start();
 		}
+		private void Emulator_Exited(object sender, EventArgs e)
+        {
+            Close();
+        }
 
 		//Tools
 		private void MessageError(string type, string path)

--- a/ShortCutes/src/Utils/Utils.cs
+++ b/ShortCutes/src/Utils/Utils.cs
@@ -225,9 +225,10 @@ namespace ShortCutes.src.Utils
         }
 
 
-        internal static string Roslyn_FormCode(Emulator emu, string gamename, string gamedir, Color color, bool forceNotToWaitWindowChange,
-                                               bool keepLauncherOpen, bool keepLauncherActive, int keepActiveDuration)
-        {
+        internal static string Roslyn_FormCode(
+            Emulator emu, string gamename, string gamedir, Color color, bool forceNotToWaitWindowChange,
+            bool keepLauncherOpen, bool keepLauncherActive, int keepActiveDuration
+        ) {
             string size = "256";
             if (RectangularDesign)
                 size = "322";

--- a/ShortCutes/src/Utils/Utils.cs
+++ b/ShortCutes/src/Utils/Utils.cs
@@ -225,7 +225,8 @@ namespace ShortCutes.src.Utils
         }
 
 
-        internal static string Roslyn_FormCode(Emulator emu, string gamename, string gamedir, Color color, bool forceNotToWaitWindowChange)
+        internal static string Roslyn_FormCode(Emulator emu, string gamename, string gamedir, Color color, bool forceNotToWaitWindowChange,
+                                               bool keepLauncherOpen, bool keepLauncherActive, int keepActiveDuration)
         {
             string size = "256";
             if (RectangularDesign)
@@ -238,11 +239,13 @@ namespace ShortCutes.src.Utils
                 waitWindowChange = emu.WaitWindowChange;
 
                 if (emu.Name == "PCSX2 QT")
+                {
                     try
                     {
                         waitWindowChange = Convert.ToBoolean(new IniFile(emu.getConfigFinalPath()).Read("EnableFastBoot", "EmuCore").Replace('/', '\\'));
                     }
                     catch { }
+                }
             }
 
             return Properties.Resources.Roslyn_Form_Code.Replace(new Dictionary<string, string>()
@@ -257,6 +260,9 @@ namespace ShortCutes.src.Utils
                 ["%avgR%"] = color.R.ToString(),
                 ["%avgG%"] = color.G.ToString(),
                 ["%avgB%"] = color.B.ToString(),
+                ["%KEEPOPEN%"] = keepLauncherOpen.ToString().ToLower(),
+                ["%KEEPACTIVE%"] = keepLauncherActive.ToString().ToLower(),
+                ["%KEEPACTIVEDURATION%"] = keepActiveDuration.ToString(),
             });
         }
 


### PR DESCRIPTION
ShortCutes is a nice tool that already allows to easily add emulators in third-party launcher apps like Armoury Crate. However, although the "ShortCute" allows to start the game from Armoury Crate, it doesn't make it compatible with Armoury Crate's game profiles, which allow for custom button mappings or power profiles. The changes made here create a little hacky compatibility.

How Armoury Crate works (according to my personal observations):
* To mark a game as "currently running" in Armoury Crate, a service monitors the currently executed processes. If any of them matches the exe file of a game entry, its state is adjusted accordingly. Thereby it doesn't matter how the game was executed or how the launch command of the game entry looks like.
* A game profile is enabled once a game's window becomes the current foreground window. 
* A game profile is disabled once any other window becomes the foreground window again. This way, the desktop mode can be enabled once you tab out of the game, even if it is still running.
* If an exe is associated with a game launcher in Armoury Crate, and its option is set that other games are allowed to be executed at the same time, it becoming the foreground window will not disable the currently applied game profile.

The state of ShortCutes before these changes:
* When a game is started and the loading pop-up is shown Armoury Crate applies the linked game profile.
* If the emulator exe is configured as a game launcher in Armoury Crate, the game profile keeps being applied after the loading pop-up disappears.
* Once any other window is shown on the screen the game profile is disabled again and cannot be applied again without re-starting the game.

The idea:
* Keep the ShortCute launcher running in the background even after the emulator loaded.
* Register a callback to foreground window changes and if the emulator window becomes the new foreground window after any other window was shown, bring back the ShortCute animation for a few seconds.
* Once the emulator process exits, exit the ShortCute process as well.

What I have implemented:
* Added two new modes that can be enabled: KeepLauncherOpen and KeepLauncherActive.
   * KeepLauncherOpen keeps the ShortCute launcher running in the background instead of exiting the process. This might be already sufficient for some game launchers.
   * KeepLauncherActive requires KeepLauncherOpen to be set and will register a callback to make the ShortCute launcher the forground window for a few seconds.

What is missing:
* I did not add any GUI functionality -> The options are disabled by default in the source code.
* I did not test with any other system than the ROG Ally + Armoury Crate.
* I did not test all emulators.